### PR TITLE
docs: in-place removal of source block macros to fix docs build

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -33,25 +33,25 @@ Using this input you can receive events from {esf-name} over http(s) connections
 
 |
 
-[source,subs="+macros,attributes"]
+[source]
 ----
 input {
-  {plugin} {
-    <<plugins-{type}s-{plugin}-port,port>> => 8080
-    <<plugins-{type}s-{plugin}-ssl_certificate,ssl_certificate>> => "/path/to/logstash.crt"
-    <<plugins-{type}s-{plugin}-ssl_key,ssl_key>> => "/path/to/logstash.key"
+  elastic_serverless_forwarder {
+    port => 8080
+    ssl_certificate => "/path/to/logstash.crt"
+    ssl_key => "/path/to/logstash.key"
   }
 }
 ----
 
 |
 
-[source,subs="+macros,attributes"]
+[source]
 ----
 input {
   elastic_serverless_forwarder {
-    <<plugins-{type}s-{plugin}-port,port>> => 8080
-    <<plugins-{type}s-{plugin}-ssl,ssl>> => false
+    port => 8080
+    ssl => false
   }
 }
 ----


### PR DESCRIPTION
## Release notes

[rn:skip]


## What does this PR do?

Fixes the docs build.

TIL that `[source]` blocks are handled as subdocuments in asciidoc, and their ability to link to the outer doc that contains them is implementation-specific. While my local docs tools can resolve the references, the docs build was broken by them 😩 

## Why is it important/What is the impact to the user?

It removes a broken thing from the docs used by the combined LS docs build.

We will need to _mutate_ the tag held in github for the versioned plugin reference to pick up this fix since it is sourcing from rubygems version number (which is less than ideal), but with net zero code changes on this pre-1.0 project I am comfortable with the ramifications.

Once merged, we will need to push a tag _deletion_ to github:

~~~
git push --delete origin v0.1.0
~~~

And then this will need to be re-tagged (preferably including a cryptographic signature). 

~~~
git fetch origin
git checkout ${PR_MERGE_COMMIT}
git tag -s v0.10
git push origin v0.1.0
~~~
