### PR TITLE
move no-codec from plugin DSL's `obsolete` to own code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## 0.1.1
+  - Fixes an issue that prevents this prototype from being instantiated in an actual Logstash pipeline [#3](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/3)
+
 ## 0.1.0
   - Working Prototype: New input to receive events from Elastic Serverless Forwarder (ESF) over HTTP(S) [#1](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/1)

--- a/lib/logstash/inputs/elastic_serverless_forwarder.rb
+++ b/lib/logstash/inputs/elastic_serverless_forwarder.rb
@@ -12,9 +12,6 @@ class LogStash::Inputs::ElasticServerlessForwarder < LogStash::Inputs::Base
 
   config_name "elastic_serverless_forwarder"
 
-  # no-codec
-  config :codec, obsolete: 'The elastic_serverless_forwarder input does not have an externally-configurable codec'
-
   # bind address
   config :host, :validate => :string, :default => "0.0.0.0"
   config :port, :validate => :number, :required => true
@@ -54,6 +51,11 @@ class LogStash::Inputs::ElasticServerlessForwarder < LogStash::Inputs::Base
 
   def initialize(*a)
     super
+
+    if original_params.include?('codec')
+      fail LogStash::ConfigurationError, 'The `elastic_serverless_forwarder` input does not have an externally-configurable `codec`'
+    end
+
     @internal_http = plugin_factory.input('http').new(inner_http_input_options)
   end
 

--- a/logstash-input-elastic_serverless_forwarder.gemspec
+++ b/logstash-input-elastic_serverless_forwarder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'logstash-input-elastic_serverless_forwarder'
-  s.version = '0.1.0'
+  s.version = '0.1.1'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Receives events from Elastic Serverless Forwarder over HTTP or HTTPS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Release notes

 - avoids triggering a bug that prevents an instance of this plugin from being included in a Logstash pipeline

## What does this PR do?

Logstash pipeline internals rely on an initialized input having a `@codec` ivar that "quacks like" a `LogStash::Codecs::Base`, and failing to provide one causes a `NoMethodError` deep in Logstash internals while converting the LIR into a CompiledPipeline (see: elastic/logstash#14828)

By removing the _entire_ `codec` config from this plugin that was previously meant to _override_ the one we inherit from `LogStash::Inputs::Base` we can avoid the above bug in Logstash core, but must do our own validation to ensure that this plugin is not explicitly configured with a `codec` directive that we would then ignore.

## Why is it important/What is the impact to the user?

This plugin can now not only be _installed_, but can actually be invoked in a real Logstash pipeline.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- [x] I have added tests that prove my fix is effective or that my feature works

