### PR TITLE
docs: add technology preview call-out, comment out internal details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.2
+  - Adds "Technology Preview" call-out to documentation
+
 ## 0.1.1
   - Fixes an issue that prevents this prototype from being instantiated in an actual Logstash pipeline [#3](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.1.2
-  - Adds "Technology Preview" call-out to documentation [#4](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/4)
+  - [DOC] Adds "Technical Preview" call-out to documentation [#4](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/4)
 
 ## 0.1.1
   - Fixes an issue that prevents this prototype from being instantiated in an actual Logstash pipeline [#3](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.1.2
-  - Adds "Technology Preview" call-out to documentation
+  - Adds "Technology Preview" call-out to documentation [#4](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/4)
 
 ## 0.1.1
   - Fixes an issue that prevents this prototype from being instantiated in an actual Logstash pipeline [#3](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/3)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,6 +58,14 @@ input {
 
 |=======================================================================================================================
 
+.Technology Preview
+****
+This {esf-name} input plugin is part of a _Technology Preview_, which means that both configuration options and implementation details are subject to change in minor releases without being preceded by deprecation warnings.
+
+Before upgrading this plugin or Logstash itself, please pay special attention to the changelogs to avoid being caught by surprise.
+****
+
+
 [id="plugins-{type}s-{plugin}-enrichment"]
 ==== Enrichment
 
@@ -65,6 +73,11 @@ This input provides _minimal enrichment_ on events, and avoids including informa
 If the decoded event has a valid ISO8601-encoded `@timestamp`, it will be used. Otherwise this required field will be populated with the current time.
 
 NOTE: Senders are advised to use care with respect to fields that are {logstash-ref}/processing.html#reserved-fields[reserved in Logstash].
+
+
+////
+// BEGIN: Elastic-internal implementation details
+//
 
 [id="plugins-{type}s-{plugin}-blocking"]
 ==== Blocking Behavior
@@ -75,6 +88,10 @@ A client that receives an HTTP request timeout is expected to retry the entire r
 
 When this plugin is blocked, it will reject _new_ requests with HTTP `429 Too Many Requests`.
 Clients that receive `429`-s are expected to wait a moment before retrying the request — exponential back-off is encouraged to ease flood recovery.
+
+//
+// END: Elastic-internal implementation details
+////
 
 [id="plugins-{type}s-{plugin}-security"]
 ==== Security

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,11 +58,11 @@ input {
 
 |=======================================================================================================================
 
-.Technology Preview
+.Technical Preview
 ****
-This {esf-name} input plugin is part of a _Technology Preview_, which means that both configuration options and implementation details are subject to change in minor releases without being preceded by deprecation warnings.
+This {esf-name} input plugin is part of a _Technical Preview_, which means that both configuration options and implementation details are subject to change in minor releases without being preceded by deprecation warnings.
 
-Before upgrading this plugin or Logstash itself, please pay special attention to the changelogs to avoid being caught by surprise.
+Before upgrading this plugin or Logstash itself, please pay special attention to this plugin's https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/blob/main/CHANGELOG.md[CHANGELOG.md] to avoid being caught by surprise.
 ****
 
 
@@ -70,9 +70,9 @@ Before upgrading this plugin or Logstash itself, please pay special attention to
 ==== Enrichment
 
 This input provides _minimal enrichment_ on events, and avoids including information about itself, the client from which it received the data, or about the original event as-decoded from the request.
-If the decoded event has a valid ISO8601-encoded `@timestamp`, it will be used. Otherwise this required field will be populated with the current time.
 
 NOTE: Senders are advised to use care with respect to fields that are {logstash-ref}/processing.html#reserved-fields[reserved in Logstash].
+      ESF sends the Logstash-required `@timestamp` field by default, but if this value is missing it will be populated with the current time.
 
 
 ////
@@ -104,7 +104,7 @@ Additionally, you may wish to authenticate clients using SSL client authenticati
 
 ===== SSL Identity
 
-In order to establish SSL with a client, this input plugin will need to present an SSL certificate that the client trusts and have access to the associated key.
+In order to establish SSL with a client, this input plugin will need to present an SSL certificate that the client trusts, and have access to the associated key.
 These are configurable with <<plugins-{type}s-{plugin}-ssl_certificate>>, <<plugins-{type}s-{plugin}-ssl_key>>, and optionally <<plugins-{type}s-{plugin}-ssl_key_passphrase>>.
 
 ===== SSL Client Authentication
@@ -114,6 +114,8 @@ By default, this plugin does not request certificates from clients during SSL ne
 It can be configured to either request or require client certificates using <<plugins-{type}s-{plugin}-ssl_client_authentication>>,
 which often also requires configuring it with a list of <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> to trust.
 When validating a certificate that is presented, <<plugins-{type}s-{plugin}-ssl_verification_mode>> controls how certificates are verified.
+
+NOTE: ESF does not currently support _presenting_ client certificates, so requesting or requiring clients to present identity is only useful when combined with an SSL-terminating proxy.
 
 ===== SSL Advanced Configuration
 
@@ -250,7 +252,7 @@ For example, the ChaCha20 family of ciphers is not supported in older versions.
 * Default value is `"none"`
 
 By default the server doesn't do any client authentication.
-This means that connections from clients are private by default, but that this input will allow SSL connections from _any_ client.
+This means that connections from clients are _private_ when SSL is enabled, but that this input will allow SSL connections from _any_ client.
 If you wish to configure this plugin to reject connections from untrusted hosts, you will need to configure this plugin to authenticate clients, and may also need to configure it with a list of `ssl_certificate_authorities`.
 
 [id="plugins-{type}s-{plugin}-ssl_handshake_timeout"]

--- a/logstash-input-elastic_serverless_forwarder.gemspec
+++ b/logstash-input-elastic_serverless_forwarder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'logstash-input-elastic_serverless_forwarder'
-  s.version = '0.1.1'
+  s.version = '0.1.2'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Receives events from Elastic Serverless Forwarder over HTTP or HTTPS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Release notes

 - docs: adds Technology Preview call-out

## What does this PR do?

 - adds a "Technology Preview" call-out to the docs page so that users are less likely to be caught by surprise if the details change
 - comments out an Elastic-internal section from the docs, since users configuring this plugin do not need that information

## Why is it important/What is the impact to the user?

As a 0.x plugin, shipped in support of a new tool that is in Technology Preview, this plugin _may_ evolve along-side that tool. Adding a "Technology Preview" helps users who adopt this plugin to understand that the normal upgrade path may include breaking changes without deprecation warnings until the plugin graduates from "Technology Preview"

Additionally, the backoff handling is effectively an Elastic-internal agreement and does not need to be in the user-facing docs, so it is commented out from the ASCIIDOC source so it will not be included in the generated HTML docs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- ~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
