### PR TITLE
Standardize SSL settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+  - Deprecates the `ssl` option in favor of `ssl_enabled` [#6](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/6)
+  - Bumps `logstash-input-http` gem version to `>= 3.7.2` (SSL-normalized)
+
 ## 0.1.2
   - [DOC] Adds "Technical Preview" call-out to documentation [#4](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/4)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -264,7 +264,7 @@ If you wish to configure this plugin to reject connections from untrusted hosts,
 * Value type is <<boolean,boolean>>
 * Default value is `true`
 
-Events are by default sent over SSL, which requires configuring this plugin to present an identity certificate using <<plugins-{type}s-{plugin}-ssl_certificate>> and key using <<plugins-{type}s-{plugin}-ssl_key>>.
+Events are, by default, sent over SSL, which requires configuring this plugin to present an identity certificate using <<plugins-{type}s-{plugin}-ssl_certificate>> and key using <<plugins-{type}s-{plugin}-ssl_key>>.
 
 You can disable SSL with `+ssl_enabled => false+`.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -51,7 +51,7 @@ input {
 input {
   elastic_serverless_forwarder {
     port => 8080
-    ssl => false
+    ssl_enabled => false
   }
 }
 ----
@@ -144,11 +144,12 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-auth_basic_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_client_authentication>> |<<string,string>>, one of `["none", "optional", "required"]`|No
 | <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_handshake_timeout>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
@@ -197,6 +198,7 @@ The TCP port to bind to
 
 [id="plugins-{type}s-{plugin}-ssl"]
 ===== `ssl`
+deprecated[0.1.3, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
 
 * Value type is <<boolean,boolean>>
 * Default value is `true`
@@ -254,6 +256,17 @@ For example, the ChaCha20 family of ciphers is not supported in older versions.
 By default the server doesn't do any client authentication.
 This means that connections from clients are _private_ when SSL is enabled, but that this input will allow SSL connections from _any_ client.
 If you wish to configure this plugin to reject connections from untrusted hosts, you will need to configure this plugin to authenticate clients, and may also need to configure it with a list of `ssl_certificate_authorities`.
+
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+* Value type is <<boolean,boolean>>
+* Default value is `true`
+
+Events are by default sent over SSL, which requires configuring this plugin to present an identity certificate using <<plugins-{type}s-{plugin}-ssl_certificate>> and key using <<plugins-{type}s-{plugin}-ssl_key>>.
+
+You can disable SSL with `+ssl_enabled => false+`.
 
 [id="plugins-{type}s-{plugin}-ssl_handshake_timeout"]
 ===== `ssl_handshake_timeout`

--- a/logstash-input-elastic_serverless_forwarder.gemspec
+++ b/logstash-input-elastic_serverless_forwarder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'logstash-input-elastic_serverless_forwarder'
-  s.version = '0.1.2'
+  s.version = '0.1.3'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Receives events from Elastic Serverless Forwarder over HTTP or HTTPS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,8 +23,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~>1.2'
   s.add_runtime_dependency 'logstash-mixin-plugin_factory_support'
-  s.add_runtime_dependency 'logstash-input-http'
+  s.add_runtime_dependency 'logstash-input-http', '>= 3.7.2'
   s.add_runtime_dependency 'logstash-codec-json_lines'
+  s.add_runtime_dependency 'logstash-mixin-normalize_config_support', '~>1.0'
 
   s.add_development_dependency 'logstash-devutils'
 

--- a/spec/inputs/elastic_serverless_forwarder_spec.rb
+++ b/spec/inputs/elastic_serverless_forwarder_spec.rb
@@ -28,7 +28,7 @@ describe LogStash::Inputs::ElasticServerlessForwarder do
   let!(:queue) { Queue.new }
 
   context 'baseline' do
-    let(:config) { super().merge('ssl' => false) }
+    let(:config) { super().merge('ssl_enabled' => false) }
     let(:scheme) { 'http' }
 
     it_behaves_like "an interruptible input plugin" do
@@ -45,7 +45,7 @@ describe LogStash::Inputs::ElasticServerlessForwarder do
   end
 
   context 'no user-defined codec' do
-    let(:config) { super().merge('ssl' => false) } # minimal config
+    let(:config) { super().merge('ssl_enabled' => false) } # minimal config
 
     ##
     # @codec ivar is required PENDING https://github.com/elastic/logstash/issues/14828
@@ -185,7 +185,7 @@ describe LogStash::Inputs::ElasticServerlessForwarder do
   end
 
   describe 'unsecured HTTP' do
-    let(:config) { super().merge('ssl' => false) }
+    let(:config) { super().merge('ssl_enabled' => false) }
     let(:scheme) { 'http' }
 
     include_examples 'successful request handling'
@@ -318,6 +318,25 @@ describe LogStash::Inputs::ElasticServerlessForwarder do
         end
 
         include_examples 'bad certificate request handling'
+      end
+    end
+  end
+
+  describe 'deprecated SSL options' do
+    let(:config) do
+      super().merge({
+        'ssl_certificate' => generated_certs_directory.join('server_from_root.crt').to_path,
+        'ssl_key'         => generated_certs_directory.join('server_from_root.key.pkcs8').to_path,
+      })
+    end
+
+    [true, false].each do |enabled|
+      context "when `ssl => #{enabled}`" do
+        let(:config) { super().merge('ssl' => enabled) }
+
+        it "sets @ssl_enabled to `#{enabled}`" do
+          expect(esf_input.instance_variable_get(:@ssl_enabled)).to be enabled
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->

Deprecates the `ssl` option in favor of `ssl_enabled`

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->

- Deprecated the `ssl` option in favor of `ssl_enabled`
- Bumped `logstash-input-http` gem to version `>= 3.7.2` (SSL-normalized)
- Updated `logstash-input-http` deprecated configs usages (`ssl`, `ssl_verify_mode`) to the new ones.

## Why is it important/What is the impact to the user?
This PR makes the plugin SSL settings consistent with the naming convention defined in the https://github.com/elastic/logstash/issues/14905. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes https://github.com/elastic/logstash/issues/15115
