### PR TITLE
Doc: Fix attributes for default codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.5
+  - [DOC] Fix attributes to accurately set and clear default codec values [#8](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/8)
+
 ## 0.1.4
   - [DOC] Adds tips for using the logstash-input-elastic_serverless_forwarder plugin with the Elasticsearch output plugin [#7](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/7)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -366,4 +366,4 @@ NOTE: Client identity is not typically validated using SSL because the receiving
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]
 
-:default_codec!:
+:no_codec!:

--- a/logstash-input-elastic_serverless_forwarder.gemspec
+++ b/logstash-input-elastic_serverless_forwarder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'logstash-input-elastic_serverless_forwarder'
-  s.version = '0.1.4'
+  s.version = '0.1.5'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Receives events from Elastic Serverless Forwarder over HTTP or HTTPS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Related: https://github.com/elastic/logstash/issues/16441

Some default codec settings are not being reset properly, and are spilling over to plugin docs in which they do not belong. 

Note that we set `:no_codec:` on Line 3, but attempted to clear it using a different attribute: `:default_codec:!`
This work fixes the mismatch in this plugin doc. 