### PR TITLE
Release prep for 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.0
+  - Promote from technical preview to GA [#10](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/10)
+
 ## 0.1.5
   - [DOC] Fix attributes to accurately set and clear default codec values [#8](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/8)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -58,14 +58,6 @@ input {
 
 |=======================================================================================================================
 
-.Technical Preview
-****
-This {esf-name} input plugin is part of a _Technical Preview_, which means that both configuration options and implementation details are subject to change in minor releases without being preceded by deprecation warnings.
-
-Before upgrading this plugin or Logstash itself, please pay special attention to this plugin's https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/blob/main/CHANGELOG.md[CHANGELOG.md] to avoid being caught by surprise.
-****
-
-
 [id="plugins-{type}s-{plugin}-enrichment"]
 ==== Enrichment
 

--- a/logstash-input-elastic_serverless_forwarder.gemspec
+++ b/logstash-input-elastic_serverless_forwarder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'logstash-input-elastic_serverless_forwarder'
-  s.version = '0.1.5'
+  s.version = '1.0.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Receives events from Elastic Serverless Forwarder over HTTP or HTTPS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This commit updates the plugin version and removes the technical preview warning
as it has been promoted to General Availability.