### PR TITLE
Remove deprecated ssl setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+  - SSL settings that were marked deprecated in version `0.1.3` are now marked obsolete, and will prevent the plugin from starting.
+  - These settings are:
+    - `ssl`, which should be replaced by `ssl_enabled`
+    - [#11](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/11)
+
 ## 1.0.0
   - Promote from technical preview to GA [#10](https://github.com/logstash-plugins/logstash-input-elastic_serverless_forwarder/pull/10)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -166,7 +166,6 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-auth_basic_password>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
-| <<plugins-{type}s-{plugin}-ssl>> |<<boolean,boolean>>|__Deprecated__
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_client_authentication>> |<<string,string>>, one of `["none", "optional", "required"]`|No
@@ -217,17 +216,6 @@ The host or ip to bind
 * Default value is `8080`
 
 The TCP port to bind to
-
-[id="plugins-{type}s-{plugin}-ssl"]
-===== `ssl`
-deprecated[0.1.3, Replaced by <<plugins-{type}s-{plugin}-ssl_enabled>>]
-
-* Value type is <<boolean,boolean>>
-* Default value is `true`
-
-Events are by default sent over SSL, which requires configuring this plugin to present an identity certificate using <<plugins-{type}s-{plugin}-ssl_certificate>> and key using <<plugins-{type}s-{plugin}-ssl_key>>.
-
-You can disable SSL with `+ssl => false+`.
 
 [id="plugins-{type}s-{plugin}-ssl_certificate"]
 ===== `ssl_certificate`
@@ -354,6 +342,18 @@ When <<plugins-{type}s-{plugin}-ssl_client_authentication>> causes a client to p
 
 NOTE: Client identity is not typically validated using SSL because the receiving server only has access to the client's outbound-ip, which is not always constant and is frequently not represented in the certificate's subject or subjectAltNames extensions.
       For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC2818 § 3.2 (HTTP over TLS -- Client Identity)]
+
+[id="plugins-{type}s-{plugin}-obsolete-options"]
++==== Elasticsearch Output Obsolete Configuration Options
+
++WARNING: As of version `2.0.0` of this plugin, some configuration options have been replaced.
++The plugin will fail to start if it contains any of these obsolete options.
+
++[cols="<,<",options="header",]
+ |=======================================================================
++|Setting|Replaced by
++| ssl | <<plugins-{type}s-{plugin}-ssl_enabled>>
+ |=======================================================================
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -159,6 +159,9 @@ filter {
 
 This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
 
+NOTE: As of version `2.0.0` of this plugin, a previously deprecated SSL setting has been removed.
+Please check out <<plugins-{type}s-{plugin}-obsolete-options>> for details.
+
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
@@ -344,16 +347,16 @@ NOTE: Client identity is not typically validated using SSL because the receiving
       For more information, see https://www.rfc-editor.org/rfc/rfc2818#section-3.1[RFC2818 § 3.2 (HTTP over TLS -- Client Identity)]
 
 [id="plugins-{type}s-{plugin}-obsolete-options"]
-+==== Elasticsearch Output Obsolete Configuration Options
+==== Elasticsearch Output Obsolete Configuration Options
 
-+WARNING: As of version `2.0.0` of this plugin, some configuration options have been replaced.
-+The plugin will fail to start if it contains any of these obsolete options.
+WARNING: As of version `2.0.0` of this plugin, some configuration options have been replaced.
+The plugin will fail to start if it contains any of these obsolete options.
 
-+[cols="<,<",options="header",]
- |=======================================================================
-+|Setting|Replaced by
-+| ssl | <<plugins-{type}s-{plugin}-ssl_enabled>>
- |=======================================================================
+[cols="<,<",options="header",]
+|=======================================================================
+|Setting|Replaced by
+| ssl | <<plugins-{type}s-{plugin}-ssl_enabled>>
+|=======================================================================
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/lib/logstash/inputs/elastic_serverless_forwarder.rb
+++ b/lib/logstash/inputs/elastic_serverless_forwarder.rb
@@ -10,7 +10,6 @@ require 'logstash/codecs/json_lines'
 
 class LogStash::Inputs::ElasticServerlessForwarder < LogStash::Inputs::Base
   include LogStash::PluginMixins::PluginFactorySupport
-  include LogStash::PluginMixins::NormalizeConfigSupport
 
   config_name "elastic_serverless_forwarder"
 
@@ -23,7 +22,6 @@ class LogStash::Inputs::ElasticServerlessForwarder < LogStash::Inputs::Base
   config :auth_basic_password,         :validate => :password
 
   # ssl-config
-  config :ssl,                         :validate => :boolean, :default => true, :deprecated => "Use 'ssl_enabled' instead."
   config :ssl_enabled,                 :validate => :boolean, :default => true
 
   # ssl-identity
@@ -41,10 +39,11 @@ class LogStash::Inputs::ElasticServerlessForwarder < LogStash::Inputs::Base
   config :ssl_supported_protocols,     :validate => :string,  :list => true
   config :ssl_handshake_timeout,       :validate => :number,  :default => 10_000
 
+  # obsolete config
+  config :ssl,                         :obsolete => "Use 'ssl_enabled' instead."
+
   def initialize(*a)
     super
-
-    normalize_ssl_configs!
 
     if original_params.include?('codec')
       fail LogStash::ConfigurationError, 'The `elastic_serverless_forwarder` input does not have an externally-configurable `codec`'
@@ -153,12 +152,6 @@ class LogStash::Inputs::ElasticServerlessForwarder < LogStash::Inputs::Base
       # enrichment avoidance
       'ecs_compatibility' => 'disabled',
     }
-  end
-
-  def normalize_ssl_configs!
-    @ssl_enabled = normalize_config(:ssl_enabled) do |normalizer|
-      normalizer.with_deprecated_alias(:ssl)
-    end
   end
 
   class QueueWrapper

--- a/logstash-input-elastic_serverless_forwarder.gemspec
+++ b/logstash-input-elastic_serverless_forwarder.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'logstash-input-elastic_serverless_forwarder'
-  s.version = '1.0.0'
+  s.version = '2.0.0'
   s.licenses = ['Apache License (2.0)']
   s.summary = "Receives events from Elastic Serverless Forwarder over HTTP or HTTPS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/elastic_serverless_forwarder_spec.rb
+++ b/spec/inputs/elastic_serverless_forwarder_spec.rb
@@ -32,7 +32,7 @@ describe LogStash::Inputs::ElasticServerlessForwarder do
     let(:scheme) { 'http' }
 
     it_behaves_like "an interruptible input plugin" do
-      let(:config) { { "port" => port, "ssl" => false } }
+      let(:config) { { "port" => port, "ssl_enabled" => false } }
     end
 
     after :each do
@@ -322,22 +322,11 @@ describe LogStash::Inputs::ElasticServerlessForwarder do
     end
   end
 
-  describe 'deprecated SSL options' do
-    let(:config) do
-      super().merge({
-        'ssl_certificate' => generated_certs_directory.join('server_from_root.crt').to_path,
-        'ssl_key'         => generated_certs_directory.join('server_from_root.key.pkcs8').to_path,
-      })
-    end
+  describe 'removed SSL options' do
+    let(:config) { super().merge('ssl' => true) }
 
-    [true, false].each do |enabled|
-      context "when `ssl => #{enabled}`" do
-        let(:config) { super().merge('ssl' => enabled) }
-
-        it "sets @ssl_enabled to `#{enabled}`" do
-          expect(esf_input.instance_variable_get(:@ssl_enabled)).to be enabled
-        end
-      end
+    it "fails with message indicating ssl configuration option is obsolete" do
+      expect { described_class.new(config) }.to raise_error(LogStash::ConfigurationError, /Use 'ssl_enabled' instead/)
     end
   end
 end


### PR DESCRIPTION
Remove the deprecated `ssl` config option and document how to replace it with `ssl_enabled`. Prep the 2.0.0 release. 