### PR TITLE
Doc: Fix formatting

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -26,12 +26,10 @@ include::{include_path}/plugin_header.asciidoc[]
 Using this input you can receive events from {esf-name} over http(s) connections to the configured <<plugins-{type}s-{plugin}-port>>.
 
 [id="plugins-{type}s-{plugin}-ext-field"]
-===== Minimum Configuration
-[cols="3a,2a"]
-|=======================================================================================================================
-|SSL Enabled              |SSL Disabled
+===== Minimum configuration
 
-|
+[id="plugins-{type}s-{plugin}-ssl-enabled"]
+====== SSL enabled
 
 [source]
 ----
@@ -44,7 +42,8 @@ input {
 }
 ----
 
-|
+[id="plugins-{type}s-{plugin}-ssl-disabled"]
+====== SSL disabled
 
 [source]
 ----
@@ -55,8 +54,6 @@ input {
   }
 }
 ----
-
-|=======================================================================================================================
 
 [id="plugins-{type}s-{plugin}-enrichment"]
 ==== Enrichment


### PR DESCRIPTION
Related: 
* https://github.com/elastic/logstash-docs-md/issues/9
* https://github.com/elastic/logstash-docs-md/pull/20
Specifically addresses formatting fixes in generated output.  Otherwise, we'd need to repeat these fixes every time we update the plugin. 

Note to reviewers: I've updated my editor settings to remove space at the end of a line, so the diff makes his look like a lot bigger effort than it really is. 
